### PR TITLE
3 投稿詳細apiの実装

### DIFF
--- a/backend/internal/controllers/post_controller.go
+++ b/backend/internal/controllers/post_controller.go
@@ -1,9 +1,12 @@
 package controllers
 
 import (
-	"github.com/gin-gonic/gin"
+	"errors"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
 )
 
 func PostList(ctx *gin.Context) {
@@ -14,5 +17,24 @@ func PostList(ctx *gin.Context) {
 		handleError(ctx, 500, err)
 	} else {
 		ctx.JSON(200, result)
+	}
+}
+
+func PostDetail(ctx *gin.Context) {
+	sid := ctx.Param("postId")
+	id, err := strconv.Atoi(sid)
+	if err != nil {
+		handleError(ctx, 500, err)
+	}
+
+	repository := repositories.NewPostRepository(DB(ctx))
+	usecase := usecases.NewPostUsecase(repository)
+	result, err := usecase.Get(id)
+	if err != nil {
+		handleError(ctx, 500, err)
+	} else if result != nil {
+		ctx.JSON(200, result)
+	} else {
+		handleError(ctx, 404, errors.New("not found"))
 	}
 }

--- a/backend/internal/interfaces/post_repository.go
+++ b/backend/internal/interfaces/post_repository.go
@@ -6,5 +6,5 @@ import (
 
 type PostRepository interface {
 	Get(id int) (*entities.Post, error)
-	List() ([]*entities.Post, error)
+	List(id *int) ([]*entities.Post, error)
 }

--- a/backend/internal/interfaces/post_repository.go
+++ b/backend/internal/interfaces/post_repository.go
@@ -5,6 +5,6 @@ import (
 )
 
 type PostRepository interface {
-	// Get(id int) (*entities.Post, error)
+	Get(id int) (*entities.Post, error)
 	List() ([]*entities.Post, error)
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -1,8 +1,9 @@
 package middleware
 
 import (
-	"github.com/gin-gonic/gin"
 	"myapp/internal/controllers"
+
+	"github.com/gin-gonic/gin"
 )
 
 func SetupRoutes(app *gin.Engine) {
@@ -11,4 +12,5 @@ func SetupRoutes(app *gin.Engine) {
 	})
 	app.GET("/hello", controllers.HelloWorld)
 	app.GET("/posts", controllers.PostList)
+	app.GET("/posts/:postId", controllers.PostDetail)
 }

--- a/backend/internal/repositories/post_repository.go
+++ b/backend/internal/repositories/post_repository.go
@@ -30,23 +30,24 @@ func NewPostRepository(conn *gorm.DB) *PostRepository {
 }
 
 func (r *PostRepository) Get(id int) (*entities.Post, error) {
-	var obj Post
-	result := r.Conn.Where("id = ?", id).First(&obj)
-	fmt.Printf("%+v\n", result)
-	fmt.Printf("%+v\n", obj)
-	if result.Error != nil {
-		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
-		}
-		return nil, result.Error
+	posts, err := r.List(&id)
+	if err != nil {
+		return nil, err
 	}
-	pe := convertPostRepositoryModelToEntity(&obj)
-	return pe, nil
+	if len(posts) == 0 {
+		return nil, errors.New("not found")
+	}
+	return posts[0], nil
 }
 
-func (r *PostRepository) List() ([]*entities.Post, error) {
+func (r *PostRepository) List(id *int) ([]*entities.Post, error) {
 	var obj []Post
-	result := r.Conn.Order("id desc").Find(&obj)
+	var result *gorm.DB
+	if id != nil {
+		result = r.Conn.Where("id = ?", id).Order("id desc").Find(&obj)
+	} else {
+		result = r.Conn.Order("id desc").Find(&obj)
+	}
 	fmt.Printf("%+v\n", result)
 	fmt.Printf("%+v\n", obj)
 	if result.Error != nil {

--- a/backend/internal/repositories/post_repository.go
+++ b/backend/internal/repositories/post_repository.go
@@ -3,9 +3,10 @@ package repositories
 import (
 	"errors"
 	"fmt"
-	"gorm.io/gorm"
 	"myapp/internal/entities"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 type PostRepository struct {
@@ -26,6 +27,21 @@ func NewPostRepository(conn *gorm.DB) *PostRepository {
 	return &PostRepository{
 		Conn: conn,
 	}
+}
+
+func (r *PostRepository) Get(id int) (*entities.Post, error) {
+	var obj Post
+	result := r.Conn.Where("id = ?", id).First(&obj)
+	fmt.Printf("%+v\n", result)
+	fmt.Printf("%+v\n", obj)
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, result.Error
+	}
+	pe := convertPostRepositoryModelToEntity(&obj)
+	return pe, nil
 }
 
 func (r *PostRepository) List() ([]*entities.Post, error) {

--- a/backend/internal/repositories/post_repository.go
+++ b/backend/internal/repositories/post_repository.go
@@ -39,8 +39,8 @@ func (r *PostRepository) List() ([]*entities.Post, error) {
 		}
 		return nil, result.Error
 	}
-	pe := convertSlices(obj, convertPostRepositoryModelToEntity)
-	return pe, nil
+	pes := convertSlices(obj, convertPostRepositoryModelToEntity)
+	return pes, nil
 }
 
 // convertSlices は []T を []U へ変換します

--- a/backend/internal/usecases/post_usecase.go
+++ b/backend/internal/usecases/post_usecase.go
@@ -19,3 +19,7 @@ func (u *PostUsecase) GetList() (
 	[]*entities.Post, error) {
 	return u.repository.List()
 }
+
+func (u *PostUsecase) Get(id int) (*entities.Post, error) {
+	return u.repository.Get(id)
+}

--- a/backend/internal/usecases/post_usecase.go
+++ b/backend/internal/usecases/post_usecase.go
@@ -17,7 +17,7 @@ func NewPostUsecase(r interfaces.PostRepository) *PostUsecase {
 
 func (u *PostUsecase) GetList() (
 	[]*entities.Post, error) {
-	return u.repository.List()
+	return u.repository.List(nil)
 }
 
 func (u *PostUsecase) Get(id int) (*entities.Post, error) {


### PR DESCRIPTION
close #3 

# やったこと
- 投稿詳細APIを実装した。
- `repositories/post_repository.go` 内で、Get 実装時には List を呼び出して実装しています。
  - https://github.com/givery-bootcamp/dena-2024-team8/pull/7/files#r1615703799
# curl の確認コマンド
```
curl localhost:9000/posts/1
```

# 動作確認のスクリーンショット
## 存在する`post`を指定した場合
![スクリーンショット 2024-05-27 17 03 37](https://github.com/givery-bootcamp/dena-2024-team8/assets/53688020/89e3a1e1-45a6-4b69-b50a-3fcc017d43e4)
## 存在しない`post`を指定した場合
![スクリーンショット 2024-05-27 17 03 50](https://github.com/givery-bootcamp/dena-2024-team8/assets/53688020/6910f89a-8547-45dd-a5a8-3c42b638b527)

