### PR TITLE
投稿一覧画面のページング

### DIFF
--- a/backend/internal/controllers/post_controller.go
+++ b/backend/internal/controllers/post_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"myapp/internal/entities"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
 	"strconv"
@@ -10,12 +11,26 @@ import (
 )
 
 func PostList(ctx *gin.Context) {
+	slimit := ctx.DefaultQuery("limit", "10")
+	soffset := ctx.DefaultQuery("offset", "0")
+	limit, err := strconv.Atoi(slimit)
+	if err != nil {
+		handleError(ctx, 500, err)
+	}
+	offset, err := strconv.Atoi(soffset)
+	if err != nil {
+		handleError(ctx, 500, err)
+	}
+
 	repository := repositories.NewPostRepository(DB(ctx))
 	usecase := usecases.NewPostUsecase(repository)
-	result, err := usecase.GetList()
+	result, err := usecase.GetList(limit, offset)
 	if err != nil {
 		handleError(ctx, 500, err)
 	} else {
+		if len(result) == 0 {
+			result = []*entities.Post{}
+		}
 		ctx.JSON(200, result)
 	}
 }

--- a/backend/internal/interfaces/post_repository.go
+++ b/backend/internal/interfaces/post_repository.go
@@ -6,5 +6,5 @@ import (
 
 type PostRepository interface {
 	Get(id int) (*entities.Post, error)
-	List(id *int) ([]*entities.Post, error)
+	List(id *int, limit int, offset int) ([]*entities.Post, error)
 }

--- a/backend/internal/repositories/post_repository.go
+++ b/backend/internal/repositories/post_repository.go
@@ -30,7 +30,7 @@ func NewPostRepository(conn *gorm.DB) *PostRepository {
 }
 
 func (r *PostRepository) Get(id int) (*entities.Post, error) {
-	posts, err := r.List(&id)
+	posts, err := r.List(&id, 1, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -40,19 +40,19 @@ func (r *PostRepository) Get(id int) (*entities.Post, error) {
 	return posts[0], nil
 }
 
-func (r *PostRepository) List(id *int) ([]*entities.Post, error) {
+func (r *PostRepository) List(id *int, limit int, offset int) ([]*entities.Post, error) {
 	var obj []Post
 	var result *gorm.DB
 	if id != nil {
 		result = r.Conn.Where("id = ?", id).Order("id desc").Find(&obj)
 	} else {
-		result = r.Conn.Order("id desc").Find(&obj)
+		result = r.Conn.Order("id desc").Limit(limit).Offset(offset).Find(&obj)
 	}
 	fmt.Printf("%+v\n", result)
 	fmt.Printf("%+v\n", obj)
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			return nil, nil
+			return []*entities.Post{}, nil
 		}
 		return nil, result.Error
 	}

--- a/backend/internal/usecases/post_usecase.go
+++ b/backend/internal/usecases/post_usecase.go
@@ -15,9 +15,9 @@ func NewPostUsecase(r interfaces.PostRepository) *PostUsecase {
 	}
 }
 
-func (u *PostUsecase) GetList() (
+func (u *PostUsecase) GetList(limit int, offset int) (
 	[]*entities.Post, error) {
-	return u.repository.List(nil)
+	return u.repository.List(nil, limit, offset)
 }
 
 func (u *PostUsecase) Get(id int) (*entities.Post, error) {


### PR DESCRIPTION
close #8 

# やったこと
- limitとoffsetをエンドポイント`/posts`のクエリパラメータとして追加

# 動作確認
```
curl "localhost:9000/posts?limit=1&offset=1"
```
<img width="844" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/60801230/ebf6d89d-7fa2-4c60-9c01-bfd97fa8c158">


```
curl "localhost:9000/posts?limit=1"
```
<img width="783" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/60801230/8a4dd5cf-e36c-426b-b048-5911b0cf6dbc">


```
curl "localhost:9000/posts?limit=1&offset=2"
```

<img width="876" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/60801230/4e061766-7447-4a27-8b75-4bae7facca12">


- 今2件しかpostがDBにないので[]を返す
