### PR TITLE
DBコンテナのhealth checkを待ってからBackendコンテナを立ち上げる

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
       - ./backend:/go/src/myapp
     command: "air"
     depends_on:
-      - db
+      db: 
+        condition: service_healthy
     environment:
       TZ: Asia/Tokyo
   frontend:
@@ -37,3 +38,10 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=training
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root"]
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 10s
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,8 @@ services:
       - MYSQL_DATABASE=training
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root"]
-      interval: 5s
-      timeout: 5s
+      interval: 1s
+      timeout: 1s
       retries: 6
-      start_period: 10s
+      start_period: 2s
 


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #21 

## 概要・やったこと
- docker-compose.ymlにDBコンテナのhealth checkを待ってからBackendコンテナを立ち上げるロジックを追加

## 動作確認の方法
```
docker-compose up
```
## 動作しているスクリーンショット
- DBが立ち上がった後にBackendが立ち上がっていることがわかる
- 
<img width="1122" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/60801230/8bf32e45-08d0-4e7f-b603-064b53f89d88">

