### PR TITLE
ローカル環境で環境変数が読み込めない問題を解消

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ENV="local" 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
         condition: service_healthy
     environment:
       TZ: Asia/Tokyo
+    env_file:
+      - .env
   frontend:
     image: node:20.12.2
     working_dir: /home/node/myapp


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #29 

## 概要・やったこと
`docker-compose.yml`で`.env`ファイルを指定し、ファイルから環境変数を読み込むように明示。

## 動作確認の方法
1. `.env.local`を`.env`にリネームする。
2. docker環境での動作確認を行う。
```
docker compose build
docker compose up
```
エラーが発生していなければ正常に動作している。

## 動作しているスクリーンショット

## レビューして欲しい箇所
