### PR TITLE
サインアウトAPIの実装

### DIFF
--- a/backend/internal/controllers/auth_controller.go
+++ b/backend/internal/controllers/auth_controller.go
@@ -1,0 +1,12 @@
+package controllers
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func SignOut(ctx *gin.Context) {
+	ctx.SetCookie("jwt", "", -1, "/", "", false, true)
+	ctx.JSON(200, gin.H{
+		"message": "signout success",
+	})
+}

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -13,4 +13,5 @@ func SetupRoutes(app *gin.Engine) {
 	app.GET("/hello", controllers.HelloWorld)
 	app.GET("/posts", controllers.PostList)
 	app.GET("/posts/:postId", controllers.PostDetail)
+	app.POST("/signout", controllers.SignOut)
 }


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #32 

related #41 
## 概要・やったこと
- `auth_controller.go`にSignOut関数を追加
- Set-CookieヘッダーにmaxAge=-1を入れて空のtokenをセットしている

## 動作確認の方法
curl -X POST http://localhost:9000/sign_out -v

## 動作しているスクリーンショット
![image](https://github.com/givery-bootcamp/dena-2024-team8/assets/60801230/889dd0f1-6aa5-4c81-9276-f3b7a0d3b8f1)

## レビューして欲しい箇所
