### PR TITLE
ユーザ認証のapi実装

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -13,6 +13,7 @@ var DBPort = 3306
 var DBName = "training"
 var DBUser = "root"
 var DBPassword = ""
+var JwtSecret = ""
 
 func init() {
 	if v := os.Getenv("HOSTNAME"); v != "" {
@@ -38,5 +39,8 @@ func init() {
 	}
 	if v := os.Getenv("DB_PASSWORD"); v != "" {
 		DBPassword = v
+	}
+	if v := os.Getenv("JWT_SECRET"); v != "" {
+		JwtSecret = v
 	}
 }

--- a/backend/internal/controllers/user_controller.go
+++ b/backend/internal/controllers/user_controller.go
@@ -1,0 +1,34 @@
+package controllers
+
+import (
+	"myapp/internal/repositories"
+	"myapp/internal/usecases"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ctxからuser_idを取得し、user_idに紐づくユーザー情報を取得して返す
+func UserDetail(ctx *gin.Context) {
+	//ctxからuserIdを取得
+	userId, exists := ctx.Get("userId")
+	if !exists {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "user_id is required"})
+		return
+	}
+	intUserId, ok := userId.(int)
+	if !ok {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "user_id is invalid"})
+		return
+	}
+
+	//userIdに紐づくユーザー情報を取得
+	repository := repositories.NewUserRepository(DB(ctx))
+	usecase := usecases.NewUserUsecase(repository)
+	result, err := usecase.Get(intUserId)
+	if err != nil {
+		handleError(ctx, http.StatusInternalServerError, err)
+	} else {
+		ctx.JSON(http.StatusOK, result)   
+	}
+}

--- a/backend/internal/interfaces/user_repository.go
+++ b/backend/internal/interfaces/user_repository.go
@@ -6,4 +6,5 @@ import (
 
 type UserRepository interface {
 	VerifyUser(username, password string) (*entities.User, error)
+	Get(id int) (*entities.User, error)
 }

--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -1,0 +1,63 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"myapp/internal/config"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt"
+)
+
+// やること
+// JWTValidをgin.HandlerFuncが返すようにする
+// JWTValidを使って、JWTの検証を行う
+
+func Auth() gin.HandlerFunc {
+	return func(ctx *gin.Context) {
+		key := config.JwtSecret
+		if key == "" {
+			// JWT_SECRETが設定されていない場合はエラーを返す
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": "JWT_SECRET is not set"})
+			ctx.Abort()
+			return
+		}
+		tokenString, err := ctx.Cookie("jwt")
+		if err != nil || tokenString == "" {
+			ctx.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+			ctx.Abort()
+			return
+		}
+		//tokenStringからpayloadを取り出す
+		token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+			// Don't forget to validate the alg is what you expect:
+			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+		
+			// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
+			return []byte(key), nil
+		})
+		if err != nil {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": ""})
+			ctx.Abort()
+			return
+		}
+
+		if claims, ok := token.Claims.(jwt.MapClaims); ok {
+			//claims["userId"]の値と型を確認
+			fmt.Printf("%T, %v\n", claims["userId"], claims["userId"])
+			floqtUserId, ok := claims["userId"].(float64)
+			if !ok {
+				ctx.JSON(http.StatusInternalServerError, gin.H{"error": ""})
+				ctx.Abort()
+				return
+			}
+			ctx.Set("userId", int(floqtUserId))
+			ctx.Next()
+		} else {
+			ctx.JSON(http.StatusInternalServerError, gin.H{"error": ""})
+			ctx.Abort()
+			return
+		}
+	}
+}

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -24,4 +24,7 @@ func SetupRoutes(app *gin.Engine) {
 	app.POST("/signin", controllers.SignIn)
 	// Swaggerのエンドポイントを設定
 	app.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	auth := app.Group("/auth", Auth())
+	auth.GET("/user", controllers.UserDetail)
+	// Userのエンドポイントを設定
 }

--- a/backend/internal/repositories/user_repository.go
+++ b/backend/internal/repositories/user_repository.go
@@ -52,3 +52,18 @@ func ConvertUserRepositoryModelToEntity(user *User) *entities.User {
 		DeletedAt: user.DeletedAt,
 	}
 }
+
+func (r *UserRepository) Get(id int) (*entities.User, error) {
+	user := &User{}
+	result := r.Conn.Where("id = ?", id).First(user)
+
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	return ConvertUserRepositoryModelToEntity(user), nil
+}

--- a/backend/internal/usecases/user_usecase.go
+++ b/backend/internal/usecases/user_usecase.go
@@ -57,3 +57,10 @@ func (u *UserUsecase) VerifyUserAndGenerateJWT(username, password string) (*enti
 		return user, nil, nil
 	}
 }
+
+// func (u *PostUsecase) Get(id int) (*entities.Post, error) {
+// 	return u.repository.Get(id)
+// }
+	func (u *UserUsecase) Get(id int) (*entities.User, error) {
+		return u.repository.Get(id)
+	}

--- a/backend/main.go
+++ b/backend/main.go
@@ -16,6 +16,7 @@ func main() {
 	app := gin.Default()
 	app.Use(middleware.Transaction())
 	app.Use(middleware.Cors())
+	// app.Use(middleware.Auth())
 	middleware.SetupRoutes(app)
 	app.Run(fmt.Sprintf("%s:%d", config.HostName, config.Port))
 }


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #33 

related #33 

## 概要・やったこと
- ユーザが認証済みかどうかcookieを用いて判定
- 認証済みならばUserを返す。

## 動作確認の方法
- このコマンドでsignin
  - `curl -X POST http://localhost:9000/signin -d "username=taro&password=password" -v`
-ユーザ取得
  - `curl -X GET http://localhost:9000/auth/user -b "jwt=帰ってきたjwtトークン"  -v` 

## 動作しているスクリーンショット
<img width="1455" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/69703740/95d54621-be61-4bba-a22d-8aa3bbebb4a5">


## レビューして欲しい箇所
動作確認です。あとは変なコードがないか
