### PR TITLE
サインインのページの実装

### DIFF
--- a/frontend/src/app/AppRoute.tsx
+++ b/frontend/src/app/AppRoute.tsx
@@ -2,12 +2,13 @@ import { Routes, Route } from "react-router-dom";
 
 import { MainLayout } from "./MainLayout";
 import { Home } from "../features/home";
-
+import { Signin } from "../features/signin";
 export const AppRoute = () => {
   return (
     <Routes>
       <Route element={<MainLayout />}>
         <Route path="/" element={<Home />} />
+        <Route path="/signin" element={<Signin />} />
       </Route>
     </Routes>
   );

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -8,7 +8,7 @@ export const Header = () => {
         aria-label="Global"
       >
         <div className="flex lg:flex-1">
-          <a href="#" className="-m-1.5 p-1.5">
+          <a href="/" className="-m-1.5 p-1.5">
             <span className="sr-only">Your Company</span>
             <img
               className="h-8 w-auto"
@@ -27,7 +27,7 @@ export const Header = () => {
           </button>
         </div>
         <div className="hidden lg:flex lg:flex-1 lg:justify-end">
-          <a href="#" className="text-sm font-semibold leading-6 text-gray-900">
+          <a href="/signin" className="text-sm font-semibold leading-6 text-gray-900">
             Log in <span aria-hidden="true">&rarr;</span>
           </a>
         </div>

--- a/frontend/src/features/signin/Signin.tsx
+++ b/frontend/src/features/signin/Signin.tsx
@@ -1,12 +1,15 @@
-import React, { useState } from 'react';
-import { useAppDispatch, useAppSelector } from '../../shared/hooks';
+import { useState } from 'react';
+import { useAppDispatch } from '../../shared/hooks';
 import { APIService } from '../../shared/services';
+import { useNavigate } from 'react-router-dom';
+
 
 export function Signin() {
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
     const [errorMessage, setErrorMessage] = useState('');
     const dispatch = useAppDispatch();
+    const navigate = useNavigate();
 
     const handleSignIn = () => {
         // ログイン処理を実行するコードをここに追加します
@@ -20,7 +23,7 @@ export function Signin() {
                 // responseからデータを取得し、ログイン成功の処理を行う
                 if (response.payload && response.payload) {
                     // homeに遷移
-                    window.location.href = "/";
+                    navigate('/');
                 } else {
                     // データが存在しない場合の処理をここに記述
                     setErrorMessage("ユーザー名またはパスワードが違います。再度お試しください。");

--- a/frontend/src/features/signin/Signin.tsx
+++ b/frontend/src/features/signin/Signin.tsx
@@ -5,6 +5,7 @@ import { APIService } from '../../shared/services';
 export function Signin() {
     const [username, setUsername] = useState('');
     const [password, setPassword] = useState('');
+    const [errorMessage, setErrorMessage] = useState('');
     const dispatch = useAppDispatch();
 
     const handleSignIn = () => {
@@ -13,8 +14,23 @@ export function Signin() {
         console.log('Password:', password);
         
         // Reduxの呼び出しをしてログイン情報を保存
-        dispatch(APIService.signin({username, password}));
-    };
+        dispatch(APIService.signin({ username, password }))
+            .then((response) => {
+                console.log("response", response);
+                // responseからデータを取得し、ログイン成功の処理を行う
+                if (response.payload && response.payload) {
+                    // homeに遷移
+                    window.location.href = "/";
+                } else {
+                    // データが存在しない場合の処理をここに記述
+                    setErrorMessage("ユーザー名またはパスワードが違います。再度お試しください。");
+                }
+            })
+            .catch((error) => {
+                // エラー発生時の処理をここに記述
+                setErrorMessage("サインインに失敗しました。再度お試しください。"+ error.message);
+            });
+        };
 
     return (
         <div className="container-xxl flex justify-center items-center">
@@ -40,6 +56,9 @@ export function Signin() {
                 >
                     Sign In
                 </button>
+                <p className="mt-4 text-red-500">
+                    { errorMessage }
+                </p>
             </div>
         </div>
     );

--- a/frontend/src/features/signin/Signin.tsx
+++ b/frontend/src/features/signin/Signin.tsx
@@ -1,10 +1,43 @@
+import React, { useState } from 'react';
+import { useAppDispatch, useAppSelector } from '../../shared/hooks';
+import { APIService } from '../../shared/services';
+
 export function Signin() {
+    const [username, setUsername] = useState('');
+    const [password, setPassword] = useState('');
+    const dispatch = useAppDispatch();
+
+    const handleSignIn = () => {
+        // ログイン処理を実行するコードをここに追加します
+        console.log('Username:', username);
+        console.log('Password:', password);
+        
+        // Reduxの呼び出しをしてログイン情報を保存
+        dispatch(APIService.signin(username, password));
+    };
+
     return (
         <div className="container-xxl flex justify-center items-center">
             <div className="flex flex-col items-center p-4">
-                <input type="text" placeholder="Username" className="mb-4 p-2 border border-gray-300 rounded" />
-                <input type="password" placeholder="Password" className="mb-4 p-2 border border-gray-300 rounded" />
-                <button type="submit" className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
+                <input
+                    type="text"
+                    placeholder="Username"
+                    className="mb-4 p-2 border border-gray-300 rounded"
+                    value={username}
+                    onChange={(e) => setUsername(e.target.value)}
+                />
+                <input
+                    type="password"
+                    placeholder="Password"
+                    className="mb-4 p-2 border border-gray-300 rounded"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                />
+                <button
+                    type="submit"
+                    className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+                    onClick={handleSignIn}
+                >
                     Sign In
                 </button>
             </div>

--- a/frontend/src/features/signin/Signin.tsx
+++ b/frontend/src/features/signin/Signin.tsx
@@ -1,0 +1,13 @@
+export function Signin() {
+    return (
+        <div className="container-xxl flex justify-center items-center">
+            <div className="flex flex-col items-center p-4">
+                <input type="text" placeholder="Username" className="mb-4 p-2 border border-gray-300 rounded" />
+                <input type="password" placeholder="Password" className="mb-4 p-2 border border-gray-300 rounded" />
+                <button type="submit" className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
+                    Sign In
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/signin/Signin.tsx
+++ b/frontend/src/features/signin/Signin.tsx
@@ -13,7 +13,7 @@ export function Signin() {
         console.log('Password:', password);
         
         // Reduxの呼び出しをしてログイン情報を保存
-        dispatch(APIService.signin(username, password));
+        dispatch(APIService.signin({username, password}));
     };
 
     return (

--- a/frontend/src/features/signin/index.ts
+++ b/frontend/src/features/signin/index.ts
@@ -1,0 +1,1 @@
+export * from './Signin';

--- a/frontend/src/shared/models/User.ts
+++ b/frontend/src/shared/models/User.ts
@@ -1,0 +1,10 @@
+// {"id":1,"name":"taro","password":"password","created_at":"2024-05-27T10:59:25+09:00","updated_at":"2024-05-27T10:59:25+09:00","deleted_at":"0001-01-01T00:00:00Z"}%   
+
+export interface User {
+    id: number;
+    name: string;
+    password: string;
+    created_at: string;
+    updated_at: string;
+    deleted_at: string;
+    }

--- a/frontend/src/shared/models/index.ts
+++ b/frontend/src/shared/models/index.ts
@@ -1,2 +1,3 @@
 export * from './Hello';
 export * from './Posts';
+export * from './User';

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -20,3 +20,27 @@ export const getPostDetail = createAsyncThunk<Post,string>('getPostDetail',async
   const response = await fetch(`${API_ENDPOINT_PATH}/posts/${postId}`);
   return await response.json();
 }) 
+
+export const signin = createAsyncThunk<Post, { username: string; password: string }>(
+  'signin',
+  async ({ username, password }) => {
+    const response = await fetch(`${API_ENDPOINT_PATH}/signin`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ username, password }),
+    });
+
+    if (!response.ok) {
+      throw new Error('サインインに失敗しました。');
+    }
+
+    const data = await response.json();
+
+    // JWTをcookieに設定する処理はフロントエンドでは実施しないのが一般的ですが、
+    // 必要に応じてサーバーからのレスポンスヘッダーを確認し、適切に処理を行ってください。
+
+    return data;
+  }
+);

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { Hello } from '../models';
-import { PostList,Post } from '../models';
+import { PostList, Post, User } from '../models';
 
 const API_ENDPOINT_PATH =
   import.meta.env.VITE_API_ENDPOINT_PATH ?? '';
@@ -21,15 +21,16 @@ export const getPostDetail = createAsyncThunk<Post,string>('getPostDetail',async
   return await response.json();
 }) 
 
-export const signin = createAsyncThunk<Post, { username: string; password: string }>(
+export const signin = createAsyncThunk<User, { username: string, password: string }>(
   'signin',
   async ({ username, password }) => {
     const response = await fetch(`${API_ENDPOINT_PATH}/signin`, {
       method: 'POST',
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
       },
-      body: JSON.stringify({ username, password }),
+      body: 'username=' + username + '&password=' + password,
+      credentials: 'include',
     });
 
     if (!response.ok) {
@@ -37,9 +38,9 @@ export const signin = createAsyncThunk<Post, { username: string; password: strin
     }
 
     const data = await response.json();
+    console.log(data);
 
-    // JWTをcookieに設定する処理はフロントエンドでは実施しないのが一般的ですが、
-    // 必要に応じてサーバーからのレスポンスヘッダーを確認し、適切に処理を行ってください。
+    // coockieにjwtというキーでUserIdをJWT化した文字列を設定する
 
     return data;
   }

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -38,9 +38,6 @@ export const signin = createAsyncThunk<User, { username: string, password: strin
     }
 
     const data = await response.json();
-    console.log(data);
-
-    // coockieにjwtというキーでUserIdをJWT化した文字列を設定する
 
     return data;
   }

--- a/frontend/src/shared/store/SigninSlice.ts
+++ b/frontend/src/shared/store/SigninSlice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { User } from '../models';
+import { APIService } from '../services';
+
+export type SigninState = {
+    Signin ?: User;
+}
+
+export const initialState : SigninState =  {}; 
+
+export const signinSlice = createSlice({
+    name: 'signin',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(APIService.signin.fulfilled, (state, action) => {
+            state.Signin = action.payload;
+        });
+    },
+});
+
+export default signinSlice.reducer;

--- a/frontend/src/shared/store/index.ts
+++ b/frontend/src/shared/store/index.ts
@@ -10,7 +10,7 @@ export const store = configureStore({
     hello: helloReducer,
     post: postReducer,
     detail : postDetailReducer,
-    sinin: signinReducer,
+    singin: signinReducer,
   },
 });
 

--- a/frontend/src/shared/store/index.ts
+++ b/frontend/src/shared/store/index.ts
@@ -3,12 +3,14 @@ import { configureStore } from '@reduxjs/toolkit';
 import helloReducer, { helloSlice } from './HelloSlice';
 import postReducer, { postSlice } from './PostsSlice';
 import postDetailReducer,{ postDetailSlice } from './PostDetailSlice'
+import signinReducer,{ signinSlice } from './SigninSlice'
 
 export const store = configureStore({
   reducer: {
     hello: helloReducer,
     post: postReducer,
     detail : postDetailReducer,
+    sinin: signinReducer,
   },
 });
 
@@ -16,6 +18,7 @@ export const actions = {
   ...helloSlice.actions,
   ...postSlice.actions,
   ...postDetailSlice.actions,
+  ...signinSlice.actions,
 };
 
 export type RootState = ReturnType<typeof store.getState>;


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #47 

related [関連するイシューをメンションする]

## 概要・やったこと

- SignInの処理を実装 
- http://localhost:3000/signin
 - ログインに成功した際の挙動
   - ログイン後にhomeへ遷移する
   - 開発者タブの「アプリケーション」にjwtが格納されている
 - 失敗した際の挙動
   - エラーが表示される

## 動作確認の方法

- http://localhost:3000/signin へアクセス
  - ユーザ名：`taro`
  - パスワード：`password`
 でログイン


## 動作しているスクリーンショット

- エラー時

<img width="506" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/51431248/d1615d10-480c-45e7-8dbb-a7151928c77c">

## レビューして欲しい箇所

- 動作の確認
- コード内容
