### PR TITLE
誤って削除されたパッケージをインポートする

### DIFF
--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -5,6 +5,7 @@ import (
 	"myapp/internal/controllers"
 
 	"github.com/gin-gonic/gin"      // swagger embed files
+	"github.com/swaggo/files"
 	"github.com/swaggo/gin-swagger" // gin-swagger middleware
 )
 


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
なし

## 概要・やったこと
[サインアウトAPIの実装 (](https://github.com/givery-bootcamp/dena-2024-team8/commit/f687a4a8af999245bd6604e978e6bfc30256e004)の修正でバックエンドのビルドができていなかったため、その問題を修正する

## 動作確認の方法
レビュー前に、`backend`コンテナを立ち上げた際に以下のエラーが表示されることを確認する
```
internal/middleware/router.go:27:50: undefined: swaggerFiles
backend-1  | failed to build, error: exit status 1
```

このブランチで再度コンテナを立ち上げた際に表示されないことを確認する

## 動作しているスクリーンショット

## レビューして欲しい箇所
