### PR TITLE
ログアウトの処理の実装

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -24,7 +24,7 @@ export const Header = () => {
         <div className="lg:flex lg:flex-1 lg:justify-end">
           <SignoutButton />
           <button onClick={() => {navigator('/signin')}} className="lg:justify-end bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
-            サインイン 
+            Login
           </button>
         </div>
       </nav>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,9 @@
 import { FaBars } from "react-icons/fa";
+import { useNavigate } from "react-router-dom";
+import SignoutButton from "./button/SignoutButton";
 
 export const Header = () => {
+  const navigator = useNavigate();
   return (
     <header className="bg-gray-100">
       <nav
@@ -17,19 +20,12 @@ export const Header = () => {
             />
           </a>
         </div>
-        <div className="flex lg:hidden">
-          <button
-            type="button"
-            className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
-          >
-            <span className="sr-only">Open main menu</span>
-            <FaBars className="h-6 w-6" aria-hidden="true" />
+
+        <div className="lg:flex lg:flex-1 lg:justify-end">
+          <SignoutButton />
+          <button onClick={() => {navigator('/signin')}} className="lg:justify-end bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded">
+            サインイン 
           </button>
-        </div>
-        <div className="hidden lg:flex lg:flex-1 lg:justify-end">
-          <a href="/signin" className="text-sm font-semibold leading-6 text-gray-900">
-            Log in <span aria-hidden="true">&rarr;</span>
-          </a>
         </div>
       </nav>
     </header>

--- a/frontend/src/components/button/SignoutButton.tsx
+++ b/frontend/src/components/button/SignoutButton.tsx
@@ -14,7 +14,7 @@ export default function SignoutButton() {
             }}
             className="lg:justify-end bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
         >
-            サインアウト
+            Logout
         </button>
     );
 }

--- a/frontend/src/components/button/SignoutButton.tsx
+++ b/frontend/src/components/button/SignoutButton.tsx
@@ -1,0 +1,20 @@
+import { useAppDispatch } from '../../shared/hooks';
+import { APIService } from '../../shared/services';
+
+export default function SignoutButton() {
+    const dispatch = useAppDispatch();
+
+    const handleSignOut = () => {
+        dispatch(APIService.signout())
+    }
+    return (
+        <button
+            onClick={() => {
+                handleSignOut();
+            }}
+            className="lg:justify-end bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded"
+        >
+            サインアウト
+        </button>
+    );
+}

--- a/frontend/src/features/signin/Signin.tsx
+++ b/frontend/src/features/signin/Signin.tsx
@@ -11,15 +11,11 @@ export function Signin() {
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
 
-    const handleSignIn = () => {
-        // ログイン処理を実行するコードをここに追加します
-        console.log('Username:', username);
-        console.log('Password:', password);
-        
+    const handleSignIn = (event: { preventDefault: () => void; }) => {
+        event.preventDefault(); // デフォルトのフォーム送信を防止
         // Reduxの呼び出しをしてログイン情報を保存
         dispatch(APIService.signin({ username, password }))
             .then((response) => {
-                console.log("response", response);
                 // responseからデータを取得し、ログイン成功の処理を行う
                 if (response.payload && response.payload) {
                     // homeに遷移
@@ -33,36 +29,39 @@ export function Signin() {
                 // エラー発生時の処理をここに記述
                 setErrorMessage("サインインに失敗しました。再度お試しください。"+ error.message);
             });
-        };
+    };
 
     return (
         <div className="container-xxl flex justify-center items-center">
+            <form onSubmit={handleSignIn}>
             <div className="flex flex-col items-center p-4">
-                <input
-                    type="text"
-                    placeholder="Username"
-                    className="mb-4 p-2 border border-gray-300 rounded"
-                    value={username}
-                    onChange={(e) => setUsername(e.target.value)}
-                />
-                <input
-                    type="password"
-                    placeholder="Password"
-                    className="mb-4 p-2 border border-gray-300 rounded"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                />
-                <button
-                    type="submit"
-                    className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
-                    onClick={handleSignIn}
-                >
-                    Sign In
-                </button>
-                <p className="mt-4 text-red-500">
-                    { errorMessage }
-                </p>
-            </div>
+                
+                    <input
+                        type="text"
+                        placeholder="Username"
+                        className="mb-4 p-2 border border-gray-300 rounded"
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                    />
+                    <input
+                        type="password"
+                        placeholder="Password"
+                        className="mb-4 p-2 border border-gray-300 rounded"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                    />
+                    <button
+                        type="submit"
+                        className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+                        
+                    >
+                        Login
+                    </button>
+                    <p className="mt-4 text-red-500">
+                        { errorMessage }
+                    </p>
+                </div>
+            </form>
         </div>
     );
 }

--- a/frontend/src/shared/models/User.ts
+++ b/frontend/src/shared/models/User.ts
@@ -8,3 +8,7 @@ export interface User {
     updated_at: string;
     deleted_at: string;
     }
+
+export interface SignOutResponse {
+    message: string;
+}

--- a/frontend/src/shared/services/API.ts
+++ b/frontend/src/shared/services/API.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import { Hello } from '../models';
-import { PostList, Post, User } from '../models';
+import { PostList, Post, User, SignOutResponse } from '../models';
 
 const API_ENDPOINT_PATH =
   import.meta.env.VITE_API_ENDPOINT_PATH ?? '';
@@ -39,6 +39,22 @@ export const signin = createAsyncThunk<User, { username: string, password: strin
 
     const data = await response.json();
 
+    return data;
+  }
+);
+
+export const signout = createAsyncThunk<SignOutResponse>(
+  'signout',
+  async () => {
+    const response = await fetch(`${API_ENDPOINT_PATH}/signout`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      throw new Error('サインアウトに失敗しました。');
+    }
+    const data = await response.json();
+    
     return data;
   }
 );

--- a/frontend/src/shared/store/SignoutSlice.ts
+++ b/frontend/src/shared/store/SignoutSlice.ts
@@ -1,0 +1,23 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+import { SignOutResponse } from '../models';
+import { APIService } from '../services';
+
+export type SignoutState = {
+    Signout ?: SignOutResponse;
+}
+
+export const initialState : SignoutState =  {}; 
+
+export const signoutSlice = createSlice({
+    name: 'signout',
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder.addCase(APIService.signout.fulfilled, (state, action) => {
+            state.Signout = action.payload;
+        });
+    },
+});
+
+export default signoutSlice.reducer;


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #51 

related [関連するイシューをメンションする]

## 概要・やったこと

- ログアウトボタンと処理を作成
- サインインをログインに変更
- SigninページでEnterでログインができるように変更

## 動作確認の方法

- ログイン時
  - [ ] Enterで送信がされる
  - [ ] 「開発者モード」の「アプリケーション」にJWTが保存されている（過去のPR内容）
 - ログアウト時
  - [ ] ログアウトボタンを押すと  「アプリケーション」のJWTが削除される

- 注意点
  - 現状ログイン状態によるボタンの表示を切り分けていないため、Headerにボタンが2つ表示される仕様です
  - バックエンドのsignout関数の関係上、 #52 がマージされた後にPRをお願いします。

## 動作しているスクリーンショット
- ログイン時
<img width="854" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/51431248/b270b141-9e95-4c11-8939-6474498c2520">

- ログアウト時
<img width="829" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/51431248/6af22413-68bd-41a3-90ed-856aa2f26fc1">

## レビューして欲しい箇所

- 動作の確認
- コードの確認
