### PR TITLE
画面レイアウトの微調整

### DIFF
--- a/frontend/src/app/AppRoute.tsx
+++ b/frontend/src/app/AppRoute.tsx
@@ -8,6 +8,7 @@ export const AppRoute = () => {
     <Routes>
       <Route element={<MainLayout />}>
         <Route path="/" element={<Home />} />
+        <Route path="/search" element={<Home />} />
         <Route path="/posts/:postId" element = {<Post />}/>
         <Route path="/signin" element={<Signin />} />
       </Route>

--- a/frontend/src/app/MainLayout.tsx
+++ b/frontend/src/app/MainLayout.tsx
@@ -6,14 +6,12 @@ export const MainLayout = () => {
   return (
     <div className="min-h-screen flex flex-col">
       <Header />
-      <main className="flex-1">
-        <div className="flex flex-row">
-          <div className="col-2 border text-center">
-            <Sidebar />
-          </div>
-          <div className="flex-1 w-full">
-            <Outlet />
-          </div>
+      <main className="flex-1 h-full flex pt-4 container mx-auto">
+        <div className="text-center">
+          <Sidebar />
+        </div>
+        <div className="w-full">
+          <Outlet />
         </div>
       </main>
     </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,7 +2,7 @@ import { FaBars } from "react-icons/fa";
 
 export const Header = () => {
   return (
-    <header className="bg-gray-100">
+    <header className="bg-blue-300">
       <nav
         className="mx-auto flex max-w-7xl items-center justify-between p-6 lg:px-8"
         aria-label="Global"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,12 +1,59 @@
-import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 export const Sidebar = () => {
+  const navigator = useNavigate();
+  const location = useLocation();
+  const [activePath, setActivePath] = useState<string>("");
+
+  useEffect(() => {
+    setActivePath(location.pathname);
+    console.log(location.pathname);
+  }, [location]);
+
   return (
-    <div className="w-40">
+    <div className="h-full min-w-48 border-r pr-2">
+      <div className="py-4 border-b-4 border-gray-300">
+        <b>メニュー</b>
+      </div>
       <nav>
-        <ul>
-          <li className="mb-2"><Link to ={"/"} className="text-blue-500">Home</Link></li>
-          <li><a href="#" className="text-blue-500">Search</a></li>
+        <ul className="mx-4 py-4 flex flex-col gap-4">
+          <li>
+            <button
+              onClick={() => navigator("/")}
+              className={`rounded py-3 border w-full active:bg-blue-200 active:shadow-inner active:shadow-black ${
+                activePath === "/"
+                  ? "text-blue-700 shadow-black shadow-inner bg-blue-200"
+                  : "text-blue-500 shadow shadow-gray-400 hover:bg-blue-100"
+              }`}
+            >
+              Home
+            </button>
+          </li>
+          <li>
+            <button
+              onClick={() => navigator("/search")}
+              className={`rounded py-3 border w-full active:bg-blue-200 active:shadow-inner active:shadow-black ${
+                activePath === "/search"
+                  ? "text-blue-700 shadow-black shadow-inner bg-blue-200"
+                  : "text-blue-500 shadow shadow-gray-400 hover:bg-blue-100"
+              }`}
+            >
+              Search
+            </button>
+          </li>
+          <li>
+            <button
+              onClick={() => navigator("/signin")}
+              className={`rounded py-3 border w-full active:bg-blue-200 active:shadow-inner active:shadow-black ${
+                activePath === "/signin"
+                  ? "text-blue-700 shadow-black shadow-inner bg-blue-200"
+                  : "text-blue-500 shadow shadow-gray-400 hover:bg-blue-100"
+              }`}
+            >
+              test
+            </button>
+          </li>
         </ul>
       </nav>
     </div>

--- a/frontend/src/features/home/Home.tsx
+++ b/frontend/src/features/home/Home.tsx
@@ -3,9 +3,9 @@ import { PostList } from "../posts/PostList";
 
 export function Home() {
   return (
-    <div className="container-xxl">
-      <div className="row">
-        <div className="border bg-white vh-100 p-3">
+    <div className="h-full">
+      <div className="row px-8">
+        <div>
           <PostForm />
           <hr />
           <PostList />


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #63 

## 概要・やったこと
サイドバーのレイアウトを調整し、見やすくする
リンクではなくボタンを使用するようにする

## やってないこと
投稿一覧のレイアウトの修正はしてないです

## 動作しているスクリーンショット
<img width="1236" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/68587102/7259d6dd-b850-4b30-a2ec-9c949018368c">
<img width="1235" alt="image" src="https://github.com/givery-bootcamp/dena-2024-team8/assets/68587102/264644c5-1502-42b2-a835-e3bc6931b58f">
