### PR TITLE
（ブランチを切り直して力技でコンフリクト解消）投稿削除機能の実装

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -230,6 +230,52 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "delete post by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "post"
+                ],
+                "summary": "delete post by id",
+                "operationId": "delete-post-by-id",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Post ID デフォルトで1から2までしかデータがありません。",
+                        "name": "postId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "不正なpostID",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "ポストが見つからない",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -219,6 +219,52 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "delete post by id",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "post"
+                ],
+                "summary": "delete post by id",
+                "operationId": "delete-post-by-id",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Post ID デフォルトで1から2までしかデータがありません。",
+                        "name": "postId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "400": {
+                        "description": "不正なpostID",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "ポストが見つからない",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/controllers.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -94,6 +94,37 @@ paths:
       tags:
       - post
   /posts/{postId}:
+    delete:
+      consumes:
+      - application/json
+      description: delete post by id
+      operationId: delete-post-by-id
+      parameters:
+      - description: Post ID デフォルトで1から2までしかデータがありません。
+        in: path
+        name: postId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: 不正なpostID
+          schema:
+            $ref: '#/definitions/controllers.ErrorResponse'
+        "404":
+          description: ポストが見つからない
+          schema:
+            $ref: '#/definitions/controllers.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/controllers.ErrorResponse'
+      summary: delete post by id
+      tags:
+      - post
     get:
       consumes:
       - application/json

--- a/backend/internal/controllers/post_controller.go
+++ b/backend/internal/controllers/post_controller.go
@@ -9,6 +9,7 @@ import (
 	"myapp/internal/external"
 	"myapp/internal/repositories"
 	"myapp/internal/usecases"
+	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -288,5 +289,35 @@ func PostUpdate(ctx *gin.Context) {
 		handleError(ctx, 400, errors.New("you are not the author of this post"))
 	} else {
 		ctx.JSON(200, result)
+	}
+}
+
+// PostDelete godoc
+// @Summary delete post by id
+// @Description delete post by id
+// @ID delete-post-by-id
+// @Tags post
+// @Accept  json
+// @Produce  json
+// @Param postId path int true "Post ID デフォルトで1から2までしかデータがありません。"
+// @Success 200
+// @Failure 400 {object} ErrorResponse "不正なpostID"
+// @Failure 404 {object} ErrorResponse "ポストが見つからない"
+// @Failure 500 {object} ErrorResponse "Internal Server Error"
+// @Router /posts/{postId} [delete]
+func PostDelete(ctx *gin.Context) {
+	sid := ctx.Param("postId")
+	id, err := strconv.Atoi(sid)
+	if err != nil {
+		handleError(ctx, 500, err)
+	}
+
+	repository := repositories.NewPostRepository(DB(ctx))
+	usecase := usecases.NewPostUsecase(repository)
+	err = usecase.Delete(id)
+	if err != nil {
+		handleError(ctx, 500, err)
+	} else {
+		ctx.Status(http.StatusOK)
 	}
 }

--- a/backend/internal/interfaces/post_repository.go
+++ b/backend/internal/interfaces/post_repository.go
@@ -9,4 +9,5 @@ type PostRepository interface {
 	List(id *int, limit int, offset int) ([]*entities.Post, error)
 	Create(title, body string, userId int) (*entities.Post, error)
 	Update(title, body string, userId, postId int) (*entities.Post, error)
+	Delete(id int) error
 }

--- a/backend/internal/middleware/router.go
+++ b/backend/internal/middleware/router.go
@@ -33,4 +33,5 @@ func SetupRoutes(app *gin.Engine) {
 	authroot := app.Group("/", Auth())
 	authroot.POST("/posts", controllers.PostCreate)
 	authroot.PUT("/posts/:postId", controllers.PostUpdate)
+	authroot.DELETE("/posts/:postId", controllers.PostDelete)
 }

--- a/backend/internal/repositories/post_repository.go
+++ b/backend/internal/repositories/post_repository.go
@@ -93,6 +93,17 @@ func (r *PostRepository) Update(title, body string, userId, postId int) (*entiti
 	return convertPostRepositoryModelToEntity(&post, &user), nil
 }
 
+func (r *PostRepository) Delete(id int) error {
+	result := r.Conn.Delete(&Post{}, id)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return errors.New("not found")
+	}
+	return nil
+}
+
 func (r *PostRepository) List(id *int, limit int, offset int) ([]*entities.Post, error) {
 	var obj []Post
 	var result *gorm.DB

--- a/backend/internal/usecases/post_usecase.go
+++ b/backend/internal/usecases/post_usecase.go
@@ -31,3 +31,7 @@ func (u *PostUsecase) Create(title, body string, userId int) (*entities.Post, er
 func (u *PostUsecase) Update(title, body string, userId, postId int) (*entities.Post, error) {
 	return u.repository.Update(title, body, userId, postId)
 }
+
+func (u *PostUsecase) Delete(id int) error {
+	return u.repository.Delete(id)
+}


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #59

## 概要・やったこと
endpoint: DELETE /posts/:postId
parameters: JSON
認証: 必要
response: 200 
Swaggerにも記載済み

## 動作確認の方法
jwt を取得
```
curl -X POST http://localhost:9000/signin -d "username=taro&password=password" -v
```

/posts にリクエストを投げる
jwt は JWT_SECRET によって異なる値が出力されるので注意。
```
curl -X DELETE http://localhost:9000/posts/1 -b "jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjF9.i-rFaVdXB6JQ2lj2LkzzKg6HexoY79WNaAD9GifwpwA" -v
```

## 動作しているスクリーンショット
![image](https://github.com/givery-bootcamp/dena-2024-team8/assets/69703740/62a83bb4-0ba2-4d93-aac0-ee8662f6b430)

![image](https://github.com/givery-bootcamp/dena-2024-team8/assets/69703740/412c4b57-d837-4a20-aa46-5e7c8252bd3c)

![image](https://github.com/givery-bootcamp/dena-2024-team8/assets/69703740/2234f1e9-75ea-4177-a056-148ac68a8c1f)


## レビューして欲しい箇所
- 動作確認