### PR TITLE
ヘルスチェックのバグ修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
     networks:
       - esnet
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsSL http://localhost:9200/_cat/health | grep -q 'yellow' || grep -q 'green'"]
+      test: ["CMD-SHELL", "curl -fsSL http://localhost:9200/_cat/health | grep -e green -e yellow"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close なし

related [関連するイシューをメンションする]

## 概要・やったこと
ヘルスチェックのコマンドがうまく動いてなかったのを修正

## 動作確認の方法
docker-compose upで、全てのコンテナ（フロント、バック、db、elasticsearch、kibana）が正常に立つ

## 動作しているスクリーンショット
![image](https://github.com/givery-bootcamp/dena-2024-team8/assets/69703740/5ea30fed-3328-4991-921e-0a77014bc9a6)

## レビューして欲しい箇所
修正したコードでちゃんと動作するか？
