### PR TITLE
フロントのbuildでgithub actionで失敗する問題を修正

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,4 +1,3 @@
-import { FaBars } from "react-icons/fa";
 import { useNavigate } from "react-router-dom";
 import SignoutButton from "./button/SignoutButton";
 


### PR DESCRIPTION
@givery-bootcamp/team-8 

## 関連するissue
close #90 

## 概要・やったこと
github actionのbuildで不要なコンポーネントを使用していることによってbuildがこけているのでその修正

## 動作確認の方法
修正したファイルで、削除されたコンポーネントが使用されていないことくらいを確認してもらえればいいかと

## レビューして欲しい箇所
